### PR TITLE
Fix completions for deprecation of caret op as well

### DIFF
--- a/completions/jump.fish
+++ b/completions/jump.fish
@@ -28,7 +28,7 @@ function __fish_jump_suggest
 			end
 	end
 
-	set pre (jump -p $pre ^/dev/null)
+	set pre (jump -p $pre 2>/dev/null)
 	or return 0
 
 	switch (commandline -t)
@@ -43,7 +43,7 @@ function __fish_jump_suggest
 
 	set dejavu (stat . | grep -Ei '(device|inode)')
 	for i in $candidates
-		set -l path (jump -p $pre/ $i ^/dev/null)
+		set -l path (jump -p $pre/ $i 2>/dev/null)
 		and set -l pathstat (stat -L $path | grep -Ei '(device|inode)')
 		and test "$pathstat" != "$dejavu"
 		and printf '%s\n' $i


### PR DESCRIPTION
In a91fbaf84f1c5c7c00561bdad818c06b5e820436 the caret was replaced to make it compatible with newer versions of fish, but the two carets in the completions script were not replaced.

As I tried to use this as an alternative to cdargs in fish and I'm heavily using autocompletion for that, I had to dig in why this wasn't working for me.

Thanks for the awesome script, this makes fish a bit easier for me to get used to!